### PR TITLE
simplifying the 'Symbols' section a bit

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,7 +323,7 @@
       <p> Learning hold-taps and thumb-shifting is the next step:</p>
       <ul>
         <li> <kbd>Nav/Num</kbd> is activated with a long press on <kbd>Space</kbd>; </li>
-        <li> introduction to hold-taps: modifier keys <kbd>Ctrl</kbd>, <kbd>OS</kbd> and 
+        <li> introduction to hold-taps: modifier keys <kbd>Ctrl</kbd>, <kbd>OS</kbd> and
           <kbd>Alt</kbd> act as <kbd>Backspace</kbd>, <kbd>Tab</kbd> and <kbd>Enter</kbd>when tapped; </li>
         <li> <kbd>Shift</kbd> and <kbd>Sym</kbd> are sticky: modifiers when held,
           dead keys when tapped. </li>
@@ -478,24 +478,26 @@
         it’s a tap-preferred on the right (<kbo>Space</kbo>), a hold-preferred on the left. This
         allows unmissable, single-hand shortcuts. </p>
 
-
       <h3 id="layer-symbols">Symbols</h3>
       <object type="image/svg+xml" data="keeb.svg" class="sym"></object>
-      <p>All 30 programming symbols are available on this single layer, wich has been 
-        fine-tuned for comfort of use: </p>
+      <p>All 30 programming symbols are available on this single layer, and their placement has been
+        optimized for comfort: </p>
       <ul>
         <li> the most common symbols are in the most comfortable positions; </li>
-        <li> no symbol ever requires <kbd>Shift</kbd> </li>
-        <li> common sequences of programming sybols can be typed without uncomfortable same-finger bigrams, 
+        <li> no symbol ever requires <kbd>Shift</kbd>; </li>
+        <li> common sequences of programming symbols can be typed without same-finger bigrams,
           either by alternating hands (<code>~/</code>, <code>);</code>, <code>&lt;/&gt;</code>,
         <code>+=</code>, <code>['']</code>, etc.) or with a single-hand roll (<code>&gt;=</code>,
         <code>/*</code>, <code>";</code>, <code>()</code>, <code>\"</code>, etc.). </li>
       </ul>
-      
-      <p>To furthermore reduce frictions in usage, the thumbs actions on the left hand were modified to ease sequences 
-        with non-alpha characters. These sequence would otherwise involve a nasty change of position of 
-        the right thumb (a same-thumb bigram), which really breaks the flow of typing. The left-hand thumb 
-        cluster of the Symbols layer allow us to access these characters without releasing the <kbd>Sym</kbd> key:</p>
+      <p> Besides, this layer has truly been designed
+        with Vim in mind, to ease advanced navigation tricks like vertical jumps with <code>{}</code>,
+        <code>()</code>, <code>[]</code> and to chain them with <code>+-</code> (on the
+        <kbd>J</kbd><kbd>K</kbd> positions), to adjust the movement line by line without releasing
+        the <kbd>Sym</kbd> key. </p>
+      <p>The Symbols layer is a core part of the <a href="https://ergol.org">Ergol</a> keyboard
+        layout and the <a href="https://github.com/OneDeadKey/arsenik">Arsenik</a> keymap: it’s been
+        tested and improved over <em>years</em>. Rough edges have been polished over time. </p>
       <svg viewBox="0 10 410 57">
         <g class="left">
           <g class="tucked thumb">
@@ -544,23 +546,17 @@
           </g>
         </g>
       </svg>
-
+      <p>Selenium has a specific concern to ease sequences with non-alpha characters without
+        releasing the <kbd>Sym</kbd> key, thus avoiding same-thumb bigrams and preserving the typing
+        flow. This is why the Symbols layer features these three actions in the left-hand thumb
+        cluster, from right to left: </p>
       <ul>
-        <li> The leftmost thumb key now activates the numeric layer of your choice (either Nav/Num or NumRow, 
-          see below) to type Symbols/Digits combos like <code>(0)</code>, <code>[1]</code>, etc. To make things 
-          even better, the <kbd>num</kbd> key is also sticky on this layer for all flavors with three thumb keys; </li>
-        <li> The home thumb key yield a <kbd>Space</kbd>, for long symbol sequences like
-          <code>:(){ :|:& };:</code>; </li>
-        <li> The rightmost thumb key yields <kbd>Enter</kbd>, to seamlessly type lines ending with a 
-          symbol (e.g. <code>;</code>). </li>
+        <li> <kbd>Enter</kbd>, to easily type a line ending after a symbol (e.g. <code>;</code>); </li>
+        <li> <kbd>Space</kbd>, for long symbol sequences like <code>:(){ :|:& };:</code>; </li>
+        <li> <kbd>num</kbd>, which activates the default numeric layer (either Nav/Num or NumRow,
+          see below), to type Symbols/Digits combos like <code>(0)</code>, <code>[1]</code>, etc.
+          This key is sticky for all flavors with three thumb keys. </li>
       </ul>
-      <p> Besides these optimisations for programming in general, this layer has truly been designed 
-        with Vim in mind, to ease advanced navigation tricks like vertical jumps with <code>{}</code>, 
-        <code>()</code>, <code>[]</code> and to chain them with <code>+-</code>, which are on the 
-        <kbd>J</kbd><kbd>K</kbd> positions, to adjust the movement line by line. </p>
-      <p>The Symbols layer is a core part of the <a href="https://ergol.org">Ergol</a> keyboard
-        layout and the <a href="https://github.com/OneDeadKey/arsenik">Arsenik</a> keymap: it’s been intensely
-        tested and improved over <em>years</em>, which explains how efficient and fuent it is to use. </p>
 
       <h3 id="layer-fun-media">Fun/Media</h3>
       <object type="image/svg+xml" data="keeb.svg" class="fun"></object>

--- a/index.html
+++ b/index.html
@@ -490,11 +490,10 @@
         <code>+=</code>, <code>['']</code>, etc.) or with a single-hand roll (<code>&gt;=</code>,
         <code>/*</code>, <code>";</code>, <code>()</code>, <code>\"</code>, etc.). </li>
       </ul>
-      <p> Besides, this layer has truly been designed
-        with Vim in mind, to ease advanced navigation tricks like vertical jumps with <code>{}</code>,
-        <code>()</code>, <code>[]</code> and to chain them with <code>+-</code> (on the
-        <kbd>J</kbd><kbd>K</kbd> positions), to adjust the movement line by line without releasing
-        the <kbd>Sym</kbd> key. </p>
+      <p> Besides, this layer has truly been designed with Vim in mind, to ease advanced
+        navigation tricks like vertical jumps with <code>{}</code>, <code>()</code>, <code>[]</code>
+        and to chain them with <code>+-</code> (on the <kbd>J</kbd><kbd>K</kbd> positions), to
+        adjust the movement line by line without releasing the <kbd>Sym</kbd> key. </p>
       <p>The Symbols layer is a core part of the <a href="https://ergol.org">Ergol</a> keyboard
         layout and the <a href="https://github.com/OneDeadKey/arsenik">Arsenik</a> keymap: it’s been
         tested and improved over <em>years</em>. Rough edges have been polished over time. </p>

--- a/index.html
+++ b/index.html
@@ -210,7 +210,6 @@
       <ul>
         <li>to work seamlessly these keys must have “hold-preferred” priority, which is not suitable for homerow-mods;</li>
         <li>this setting makes it <em></em>much easier<em></em> to chain several uppercase letters or symbols.</li>
-
       </ul>
       <p>Having <kbd>Shift</kbd> as a homerow-mod is often recommended… and a very common reason why HRMs as a whole are
         so difficult to tune right: capitalizing a word while typing text requires <kbd>Shift</kbd>

--- a/index.html
+++ b/index.html
@@ -492,11 +492,11 @@
       </ul>
       <p> Besides, this layer has truly been designed with Vim in mind, to ease advanced
         navigation tricks like vertical jumps with <code>{}</code>, <code>()</code>, <code>[]</code>
-        and to chain them with <code>+-</code> (on the <kbd>J</kbd><kbd>K</kbd> positions), to
-        adjust the movement line by line without releasing the <kbd>Sym</kbd> key. </p>
-      <p>The Symbols layer is a core part of the <a href="https://ergol.org">Ergol</a> keyboard
-        layout and the <a href="https://github.com/OneDeadKey/arsenik">Arsenik</a> keymap: it’s been
-        tested and improved over <em>years</em>. Rough edges have been polished over time. </p>
+        followed by <code>+-</code> (on the <kbd>J</kbd><kbd>K</kbd> positions), to adjust the
+        movement line by line without releasing the <kbd>Sym</kbd> key. </p>
+      <p>The Symbols layer is a core part of the <a href="https://ergol.org">Ergol</a> layout and
+        the <a href="https://github.com/OneDeadKey/arsenik">Arsenik</a> keymap: it’s been tested and
+        improved over <em>years</em>. Rough edges have been polished over time. </p>
       <svg viewBox="0 10 410 57">
         <g class="left">
           <g class="tucked thumb">
@@ -545,7 +545,7 @@
           </g>
         </g>
       </svg>
-      <p>Selenium has a specific concern to ease sequences with non-alpha characters without
+      <p>Selenium adds a specific concern to ease sequences with non-alpha characters without
         releasing the <kbd>Sym</kbd> key, thus avoiding same-thumb bigrams and preserving the typing
         flow. This is why the Symbols layer features these three actions in the left-hand thumb
         cluster, from right to left: </p>


### PR DESCRIPTION
A quick follow-up after your PR #9.

## Wording

As a general statement: when in doubt, I think we should favor a “low profile” wording — concise, humble, to the point. We’re super happy with Arsenik and Selenium, but I believe readers are looking for facts more than enthusiasm. :-)

I’ve proposed a couple changes here to stick a bit more to this principle.

## Structure

The more serious modification concerns the structure of the `Symbols` section, which I see as follows:
- first an explanation of the 3×10 layer itself, which is inherited from Arsenik and Ergol/Lafayette;
- then an explanation of the Selenium-specific thumb cluster trick, which helps typing whole sequences without releasing the <kbd>Sym</kbd> key.

And I think the SVG representing the thumb cliusters makes a natural separation between these two parts, without requiring additional headings. Most of this PR is about restoring this structure.

As we seem to share a preference for lists over plaintext, I’ve proposed to factorize the list of left thumb actions so each item can start with a key reference.

WDYT?