### PR TITLE
refactor: swap prev and next on media layer

### DIFF
--- a/keeb.svg
+++ b/keeb.svg
@@ -705,7 +705,7 @@
                   <text class="layerNum">&amp;</text>
                   <text class="layerNav">7</text>
                   <use  class="layerVim" href="#glyph_pgdown"/>
-                  <text class="layerFun shortcut">prev</text>
+                  <text class="layerFun shortcut">next</text>
                 </g>
                 <g id="KeyJ" class="key home dual">
                   <rect/>
@@ -727,7 +727,7 @@
                   <text class="layerNum">,</text>
                   <text class="layerNav">1</text>
                   <text class="layerVim"></text>
-                  <text class="layerFun shortcut">next</text>
+                  <text class="layerFun shortcut">prev</text>
                 </g>
               </g>
 


### PR DESCRIPTION
The top row of the media layer has volume + and brightness +, so in my mind top-row = "more". For me, the "next" media-key is much more inline with "more" than the "previous" media-key, so I propose we swap them, to keep this layer more consistent.