### PR TITLE
add mouse scroll to vimnav layer

### DIFF
--- a/keeb.svg
+++ b/keeb.svg
@@ -655,7 +655,7 @@
               <text class="layerSym">:</text>
               <text class="layerNum">:</text>
               <text class="layerNav">3</text>
-              <text class="layerVim"></text>
+              <text class="layerVim">🖰→</text>
               <text class="layerFun shortcut">bri-</text>
             </g>
           </g>
@@ -691,7 +691,7 @@
                 <text class="layerSym">;</text>
                 <text class="layerNum">.</text>
                 <text class="layerNav">2</text>
-                <text class="layerVim"></text>
+                <text class="layerVim">🖰↑</text>
                 <text class="layerFun shortcut">vol-</text>
               </g>
            </g>
@@ -727,7 +727,7 @@
                   <text class="layerSym">!</text>
                   <text class="layerNum">,</text>
                   <text class="layerNav">1</text>
-                  <text class="layerVim"></text>
+                  <text class="layerVim">🖰↓</text>
                   <text class="layerFun shortcut">prev</text>
                 </g>
               </g>
@@ -759,7 +759,7 @@
                     <text class="layerSym">|</text>
                     <text class="layerNum">-</text>
                     <text class="layerNav">,</text>
-                    <text class="layerVim"></text>
+                    <text class="layerVim">←🖰</text>
                   </g>
                 </g>
                 <g class="col1m">


### PR DESCRIPTION
Following the merge of https://github.com/OneDeadKey/zmk-config-aekeynox/pull/86, this PR adds the mouse scroll icons to the vim variant of Selenium.

Note: `selenium-vim.png` should also be updated in theory, but I’m not quite sure how it was generated in the first place. If there is a simple command to refresh the PNGs when the source SVG or CSS have changed, it may be worth mentioning it in a `CONTRIBUTING.md` file?