### PR TITLE
fix: add insert key inside fn/media layer on svg pictures

### DIFF
--- a/keeb.svg
+++ b/keeb.svg
@@ -621,6 +621,7 @@
             <text class="layerNum">/</text>
             <text class="layerNav">.</text>
             <text class="layerVim"></text>
+            <text class="layerFun shortcut">ins</text>
           </g>
         </g>
 


### PR DESCRIPTION
As discuss on [discord](<https://discord.com/channels/1046720208171175946/1046720208619974658/1541818123114774670>)
`Ins` key is present on the `Fn/Media` layer but not shown on the website
<https://github.com/OneDeadKey/qmk-config-aekeynox/blob/main/selenium/keymap.c#L92>
This PR correct this.